### PR TITLE
readme: missing install in pip3 install -r requierements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Now depending on your shell settings, you might see `(e) dsopp_venv` in your ter
 From the root of this repository run:
 
 ```
-pip3 -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 #### system dependencies


### PR DESCRIPTION
Missing "install" in the installation command  `pip3 install -r requirements.txt`