### PR TITLE
Adding zip, unzip and gdown dependencies

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -55,7 +55,6 @@ RUN apt-get update && apt-get install build-essential software-properties-common
     && pip3 install typing_extensions \
     && pip3 install dataclasses \
     && pip3 install laspy \
-    && pip3 install gdown \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install build-essential software-properties-common
     libeigen3-dev \
     libsuitesparse-dev \
     git \
+    zip \
+    unzip \
     && pip3 install --upgrade pip \
     && pip3 install cmake-format \
     && pip3 install conan \
@@ -53,6 +55,7 @@ RUN apt-get update && apt-get install build-essential software-properties-common
     && pip3 install typing_extensions \
     && pip3 install dataclasses \
     && pip3 install laspy \
+    && pip3 install gdown \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
These dependencies "zip, unzip and gdown"  are used by repo, but not installed within the docker