### PR TITLE
adding '--net=host ' to docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ xhost local:docker
 And following command to open shell inside `dsopp:main` image in the current directory:
 
 ```
-docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e HOME=$HOME -e DISPLAY=$DISPLAY -w $(pwd) -v $HOME:$HOME --device=/dev/dri:/dev/dri -it dsopp:main bash
+docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e HOME=$HOME --net=host -e DISPLAY=$DISPLAY -w $(pwd) -v $HOME:$HOME --device=/dev/dri:/dev/dri -it dsopp:main bash
 ```
 
 </details>


### PR DESCRIPTION
In Ubuntu 20.04, with the default ```docker run``` command mentioned in Github README, Pangolin can not run the GUI,

```bash
(base) user@info: path_to/DSOPP$ ./build/src/application/dsopp_main
terminate called after throwing an instance of 'std::runtime_error'
  what():  Pangolin X11: Failed to open X display
Aborted (core dumped)
```

After explicitly mentioning network driver to host "--net=host", I could run GUI.

```bash
docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e HOME=$HOME --net=host -e DISPLAY=$DISPLAY -w $(pwd) -v $HOME:$HOME --device=/dev/dri:/dev/dri -it dsopp:main bash
```
I suspect that the default network driver "bridge" does not go well/allow the X11 protocol that OpenGL/pangolin uses.

